### PR TITLE
Unable to install eventbrite sdk in a new virtualenv

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,8 @@ try:
 except ImportError:
     from distutils.core import setup
 
-from eventbrite import __version__
+sys.path.append('./eventbrite')
+from _version import __version__
 
 version = __version__
 


### PR DESCRIPTION
I ran into an issue trying to install this sdk in a newly created virtualenv. 
The error:
```
Downloading/unpacking eventbrite==3.0.2 (from -r requirements.txt (line 1))
  Downloading eventbrite-3.0.2.tar.gz
  Running setup.py (path:/Users/jlong/dev/an_empty_project/a_blank_venv/build/eventbrite/setup.py) egg_info for package eventbrite
    Traceback (most recent call last):
      File "<string>", line 17, in <module>
      File "/Users/jlong/dev/an_empty_project/a_blank_venv/build/eventbrite/setup.py", line 11, in <module>
        from eventbrite import __version__
      File "eventbrite/__init__.py", line 10, in <module>
        from .client import Eventbrite
      File "eventbrite/client.py", line 6, in <module>
        import requests
    ImportError: No module named requests
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 17, in <module>

  File "/Users/jlong/dev/an_empty_project/a_blank_venv/build/eventbrite/setup.py", line 11, in <module>

    from eventbrite import __version__

  File "eventbrite/__init__.py", line 10, in <module>

    from .client import Eventbrite

  File "eventbrite/client.py", line 6, in <module>

    import requests

ImportError: No module named requests
```

Due to __version__ being imported into the base eventbrite package, which also imports the Eventbrite client;
setup.py had a dependency on requests being installed in the virtualenv before the sdk could be.