### PR TITLE
Get __version__ directly from _version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     from distutils.core import setup
 
-from eventbrite import __version__
+from eventbrite._version import __version__
 
 version = __version__
 


### PR DESCRIPTION
Importing `__version__` from the `eventbrite` module causes the `client` module to be loaded, which in turn tries to import `requests`. If `requests` is not installed, we get an `ImportError`.

Although the `setup.py` lists `requests` as a requirement, it falls over before it can be installed.

This changes the import to come from `eventbrite._version`, thus sidestepping the issue.

This fixes the same issue as #16, but in another way.