### PR TITLE
Add publish unpublish methods

### DIFF
--- a/eventbrite/apiv3_url_mapping.json
+++ b/eventbrite/apiv3_url_mapping.json
@@ -19,6 +19,18 @@
     },
     {
         "data_type": "serialized",
+        "response_type": "single_response",
+        "serializer": "Event",
+        "url_regexp": "^events/(?P<event_id>\\d+)/publish/$"
+    },
+    {
+        "data_type": "serialized",
+        "response_type": "single_response",
+        "serializer": "Event",
+        "url_regexp": "^events/(?P<event_id>\\d+)/unpublish/$"
+    },
+    {
+        "data_type": "serialized",
         "response_type": "paginated_response",
         "serializer": "Order",
         "url_regexp": "^events/(?P<event_id>\\d+)/orders/$"

--- a/eventbrite/client.py
+++ b/eventbrite/client.py
@@ -217,6 +217,9 @@ class Eventbrite(AccessMethodsMixin):
 
         return self.post("/events/%s/unpublish/" % event_id)
 
+    def post_event_ticket_class(self, event_id, data):
+        return self.post("/events/{0}/ticket_classes/".format(event_id), data=data)
+
     def event_search(self, **data):
         # Resolves the search result response problem
         return self.get("/events/search/", data=data)

--- a/eventbrite/client.py
+++ b/eventbrite/client.py
@@ -209,6 +209,14 @@ class Eventbrite(AccessMethodsMixin):
 
         return self.post("/events/", data=data)
 
+    def publish_event(self, event_id):
+
+        return self.post("/events/%s/publish/" % event_id)
+
+    def unpublish_event(self, event_id):
+
+        return self.post("/events/%s/unpublish/" % event_id)
+
     def event_search(self, **data):
         # Resolves the search result response problem
         return self.get("/events/search/", data=data)

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -37,7 +37,7 @@ class TestClient(unittest.TestCase):
         payload = eventbrite.api("get", "/users/me/", {})
 
         self.assertEqual(
-            sorted([u'id', u'first_name', u'last_name', u'emails', u'name']),
+            sorted([u'id', u'image_id', u'first_name', u'last_name', u'emails', u'name']),
             sorted(payload.keys())
         )
 

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -2,7 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from datetime import datetime
+from datetime import datetime, timedelta
+from time import strftime
 import os
 
 from eventbrite import Eventbrite
@@ -21,6 +22,8 @@ try:
 except KeyError:
     skip_user_id_tests = True
 
+EB_ISO_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
+
 
 class TestEvents(unittest.TestCase):
 
@@ -32,29 +35,8 @@ class TestEvents(unittest.TestCase):
         condition=skip_integration_tests,
         reason='Needs an OAUTH_TOKEN')
     def test_post_event(self):
-
         event_name = 'client_test_{0}'.format(datetime.now())
-
-        event_data = {
-            'event.name': {
-                'html': event_name,
-            },
-            'event.start': {
-                'utc': '2015-03-07T20:00:00Z',
-                'timezone': 'America/Los_Angeles',
-            },
-            'event.end': {
-                'utc': '2015-03-07T23:00:00Z',
-                'timezone': 'America/Los_Angeles',
-            },
-            'event.currency': 'USD',
-            'event.online_event': True,
-            'event.listed': False,
-            'event.category_id': '110',
-            'event.format_id': '5',
-            'event.password': "test",
-            'event.capacity': 10,
-        }
+        event_data = self._get_event_data(event_name)
         event = self.eventbrite.post_event(event_data)
         self.assertEqual(event_name, event['name']['text'])
         self.assertEqual(event_name, event['name']['html'])
@@ -73,6 +55,36 @@ class TestEvents(unittest.TestCase):
         }
         events = self.eventbrite.event_search(**data)
         self.assertLess(events['pagination'][u'object_count'], 1000)
+
+    def _get_event_data(self, event_name=None):
+        """ Returns a dictionary representing a valid event """
+
+        if not event_name:
+            event_name = 'client_test_{0}'.format(datetime.now())
+
+        event_data = {
+            'event.name': {
+                'html': event_name,
+            },
+            'event.start': {
+                'utc': (datetime.now() + timedelta(days=1)).strftime(EB_ISO_FORMAT),
+                'timezone': 'America/Los_Angeles',
+            },
+            'event.end': {
+                'utc': (datetime.now() + timedelta(days=1,hours=1)).strftime(EB_ISO_FORMAT),
+                'timezone': 'America/Los_Angeles',
+            },
+            'event.currency': 'USD',
+            'event.online_event': True,
+            'event.listed': False,
+            'event.category_id': '110',
+            'event.format_id': '5',
+            'event.password': "test",
+            'event.capacity': 10,
+        }
+
+        return event_data
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -55,7 +55,7 @@ class TestEvents(unittest.TestCase):
             'event.password': "test",
             'event.capacity': 10,
         }
-        event = self.eventbrite.post('/events/', data=event_data)
+        event = self.eventbrite.post_event(event_data)
         self.assertEqual(event_name, event['name']['text'])
         self.assertEqual(event_name, event['name']['html'])
         # Just for access to see the event, not full authentication


### PR DESCRIPTION
This PR adds the following methods to the api client:

* publish_event
* unpublish_event
* post_event_ticket_class

I have read the contributor guidelines, but am confused about where to add documentation. Please let me know where I should document these new methods.