### PR TITLE
[MINOR] Update supported Python versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,8 @@ pip-log.txt
 # Unit test / coverage reports
 .coverage
 .tox
-nosetests.xml
+pytests.xml
+.pytest_cache/
 htmlcov
 
 # Translations

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,23 @@
-# Config file for automatic testing at travis-ci.org
-
 language: python
+os: linux
 
 python:
-  - "3.4"
-  - "3.3"
+  - "3.7"
+  - "3.6"
+  - "3.5"
   - "2.7"
-  - "2.6"
+  - "pypy3"
   - "pypy"
-
-os:
-  - linux
-
-# command to install dependencies, e.g. pip install -r requirements.txt
-install: pip install -r requirements.txt
-
-# command to run tests
-script: py.test tests
 
 before_install:
   - pip install codecov
+
+install:
+  - pip install -e ".[testing]"
+
+script:
+  - flake8
+  - pytest
 
 after_success:
   - codecov

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -55,19 +55,19 @@ If you are proposing a feature:
 Get Started!
 ------------
 
-Ready to contribute? Here's how to set up `eventbrite` for local development.
+Ready to contribute? Here's how to set up `eventbrite-sdk-python` for local development.
 
-1. Fork the `eventbrite` repo on GitHub.
+1. Fork the `eventbrite-sdk-python` repo on GitHub.
 2. Clone your fork locally::
 
-    $ git clone git@github.com:your_name_here/eventbrite.git
+    $ git clone git@github.com:your_name_here/eventbrite-sdk-python.git
 
 3. Install your local copy into a virtualenv. Assuming you have virtualenvwrapper installed, this is how you set up your fork for local development::
 
-    $ mkvirtualenv eventbrite
-    $ cd eventbrite/
+    $ mkvirtualenv eventbrite-sdk-python
+    $ cd eventbrite-sdk-python/
     $ python setup.py develop
-    $ pip install -r requirements.txt
+    $ pip install -e ".[testing]"
 
 4. Create a branch for local development::
 
@@ -77,8 +77,8 @@ Ready to contribute? Here's how to set up `eventbrite` for local development.
 
 5. When you're done making changes, check that your changes pass flake8 and the tests, including testing other Python versions with tox::
 
-    $ flake8 eventbrite tests
-    $ py.test tests
+    $ flake8
+    $ pytest
     $ tox
 
    To get flake8 and tox, just pip install them into your virtualenv.
@@ -111,8 +111,8 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.6, 2.7, 3.3, and 3.4, and for PyPy. Check
-   https://travis-ci.org/eventbrite/eventbrite-sdk-python/pull_requests
+3. The pull request should work for Python 2.7, 3.5, 3.6, and 3.7, and for PyPy, and PyPy3.
+   Check https://travis-ci.org/eventbrite/eventbrite-sdk-python/pull_requests
    and make sure that the tests pass for all supported Python versions.
 
 Tips

--- a/Makefile
+++ b/Makefile
@@ -32,16 +32,16 @@ clean-test:
 	rm -fr htmlcov/
 
 lint:
-	flake8 eventbrite tests
+	flake8
 
 test:
-	py.test
+	pytest
 
 test-all:
 	tox
 
 coverage:
-	coverage run --source eventbrite -m py.test
+	coverage run --source eventbrite -m pytest
 	coverage report -m
 	coverage html
 	open htmlcov/index.html

--- a/eventbrite/compat.py
+++ b/eventbrite/compat.py
@@ -2,22 +2,22 @@
 
 import sys
 
+
 PY3 = sys.version_info[0] == 3
-OLD_PY2 = sys.version_info[:2] < (2, 7)
 
 
 if PY3:
     string_type = str
 else:
-    string_type = basestring
+    string_type = basestring  # noqa: F821
 
 
 try:  # pragma: no cover
-    # For python 2.6
+    # FIXME: This import must be kept to avoid a breaking change in environments
+    # that install `simplejson`, even in newer Python versions.
     import simplejson as json
 except ImportError:
-    # For python 2.7+
-    import json  # noqa
+    import json  # noqa: F401
 
 try:
     from urllib.parse import (
@@ -25,7 +25,7 @@ try:
         urljoin,
     )
 except ImportError:
-    from urlparse import (  # noqa
+    from urlparse import (  # noqa: F401
         urlparse,
         urljoin,
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-wheel==0.23.0
-requests>=2.0
-mock
-unittest2
-pytest==2.6.4
-flake8
-coverage

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,6 @@
 universal = 1
 
 [flake8]
-ignore = E501,E128
 max-complexity = 15
-exclude = *docs/*,*tests/*,*build/*,eventbrite/access_methods.py
+max-line-length = 120
+exclude = *docs/*,*tests/*,*build/*,eventbrite/access_methods.py,.tox

--- a/setup.py
+++ b/setup.py
@@ -21,17 +21,25 @@ if sys.argv[-1] == 'publish':
     sys.exit()
 
 if sys.argv[-1] == 'test':
-    os.system('py.test')
+    os.system('pytest')
     sys.exit()
 
-readme = open('README.rst').read()
-history = open('HISTORY.rst').read().replace('.. :changelog:', '')
+with open('README.rst') as readme_file:
+    readme = readme_file.read()
+with open('HISTORY.rst') as history_file:
+    history = history_file.read().replace('.. :changelog:', '')
 
-requirements = ["requests>=2.0", ]
+install_requires = [
+    "requests>=2.0",
+]
 
-# Add Python 2.6-specific dependencies
-if sys.version_info[:2] < (2, 7):
-    requirements.append('simplejson')
+tests_require = [
+    'coverage',
+    'flake8',
+    'mock; python_version < "3"',
+    'pytest',
+
+]
 
 setup(
     name='eventbrite',
@@ -44,10 +52,15 @@ setup(
     packages=[
         'eventbrite',
     ],
-    package_dir={'eventbrite':
-                 'eventbrite'},
+    package_dir={
+        'eventbrite': 'eventbrite',
+    },
     include_package_data=True,
-    install_requires=requirements,
+    install_requires=install_requires,
+    tests_require=tests_require,
+    extras_require={
+        'testing': tests_require,
+    },
     license="Apache",
     zip_safe=False,
     keywords='eventbrite',
@@ -61,11 +74,11 @@ setup(
         'Operating System :: MacOS :: MacOS X',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Internet :: WWW/HTTP',

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,10 +1,6 @@
-# flake8: noqa
+import unittest
+
 try:
     from unittest import mock
 except ImportError:
     import mock
-
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
-envlist = py26, py27, py33, py34
-skip_missing_interpreters = True
+envlist =
+    py27, py35, py36, py37, pypy, pypy3
+skip_missing_interpreters = true
 
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/eventbrite
-commands = py.test
-deps =
-    -r{toxinidir}/requirements.txt
+extras =
+    testing
+commands = pytest


### PR DESCRIPTION
* Add CI testing for Python 3.5, 3.6, 3.7, and PyPy3.
* Remove support for deprecated Python versions 2.6, 3.3, and 3.4.
* Change testing requirement management to use `setup.py` instead.
* Update contributing docs.
* Update Tox configuration accordingly.