### PR TITLE
Bump to 3.3.5

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,14 +3,21 @@
 History
 -------
 
+3.3.5 (2020-03-16)
+------------------
+
+* Added testing and support for Python versions up to 3.8, along with PyPy 3.
+* Remove support for deprecated Python versions 2.6, 3.3, and 3.4.
+* Fixed ``get_format()`` and ``get_formats()`` methods, to use the right endpoint.
+
 3.3.4 (2016-05-05)
--------------------
+------------------
 
 * Added new organizers endpoint (thanks tp @mgrdcm)
     * GET /organizers/:id/events/
 
 3.3.3 (2015-08-24)
--------------------
+------------------
 
 * Added 3 new user endpoints, thanks to @jon-ga (#29)
 

--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ Because this client interacts with Eventbrite's third API (a.k.a. APIv3), we are
 
 * 3.x.x where '3' matches the API version. This will not change until Eventbrite releases a new API version.
 * x.0.x where '0' is increased any time there is a significant change to the API that possibly breaks backwards compatibility
-* x.x.1 where '1' is increased on any release that does not break backwards comptability (small, new features, enhancements, bugfixes)
+* x.x.1 where '1' is increased on any release that does not break backwards compatibility (small, new features, enhancements, bugfixes)
 
 .. _requests: https://pypi.python.org/pypi/requests
 .. _Eventbrite: https://www.eventbrite.com

--- a/eventbrite/__init__.py
+++ b/eventbrite/__init__.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 __author__ = 'Daniel Greenfeld'
 __email__ = 'danny@eventbrite.com'
-__version__ = '3.3.4'
+__version__ = '3.3.5'
 
 
 from .client import Eventbrite  # noqa

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     from distutils.core import setup
 
-__version__ = '3.3.4'
+__version__ = '3.3.5'
 
 if sys.argv[-1] == 'tag':
     os.system("git tag -a %s -m 'version %s'" % (__version__, __version__))


### PR DESCRIPTION
* Added testing and support for Python versions up to 3.8, along with PyPy 3.
* Remove support for deprecated Python versions 2.6, 3.3, and 3.4.
* Fixed ``get_format()`` and ``get_formats()`` methods, to use the right endpoint.