### PR TITLE
Allow user to set explicit timeout for get

### DIFF
--- a/eventbrite/client.py
+++ b/eventbrite/client.py
@@ -51,7 +51,7 @@ class Eventbrite(AccessMethodsMixin):
         return method(path, data)
 
     @objectify
-    def get(self, path, data=None, expand=()):
+    def get(self, path, data=None, expand=(), timeout=None):
         # Resolves the search result response problem
         headers = self.headers
         if 'content-type' in headers:
@@ -72,7 +72,7 @@ class Eventbrite(AccessMethodsMixin):
         else:
             # Anything else is None
             data['expand'] = 'none'
-        return requests.get(path, headers=headers, params=data or {})
+        return requests.get(path, headers=headers, params=data or {}, timeout=timeout)
 
     @objectify
     def post(self, path, data=None):


### PR DESCRIPTION
I have been seeing hanging get requests to Eventbrite API. Rather than try to hack my own function timeouts, I thought it would be reasonable to use requests built-in timeouts. 

From requests documentation https://requests.readthedocs.io/en/master/user/quickstart/#timeouts
> Nearly all production code should use this parameter in nearly all requests.